### PR TITLE
Delete role policies first before deleting a role

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,13 +23,19 @@ put_role_policy = aws iam put-role-policy \
 	--policy-name $(notdir $(basename $(1))) \
 	--policy-document file://$(1)
 
-update-role: policies = $(filter-out config/policies/TrustRelationship.json, $(wildcard config/policies/*.json))
+policies = $(filter-out config/policies/TrustRelationship.json, $(wildcard config/policies/*.json))
+
 update-role: config/role-arn
 	$(foreach policy,$(policies),$(call put_role_policy,$(policy);))
 
+delete_role_policy = aws iam delete-role-policy \
+		--role-name "$(ROLE_NAME)" \
+		--policy-name $(notdir $(basename $(1)))
+
 delete-role:
-	aws iam delete-role \
-		--role-name "$(ROLE_NAME)"
+		$(foreach policy, $(policies), $(call delete_role_policy,$(policy));)
+		aws iam delete-role --role-name "$(ROLE_NAME)"
+		$(shell rm config/role-arn)
 
 role_arn = $(shell cat config/role-arn)
 create_function = aws lambda create-function \


### PR DESCRIPTION
Hi, first of, great work on this, it has been so helpful to me and thank you for that.

Trying to run `make delete-role` I've got the following error from AWS:

```
An error occurred (DeleteConflict) when calling the DeleteRole operation: Cannot delete entity, must delete policies first.
make: *** [delete-role] Error 255
```

So, this PR contemplates an additional step before deleting a role, which is the one in charge of deleting its policies associated.

Let me know any question in regards of this.
Ronny

PD: I have a question and I wanted to take advantage of this space. Line 1 says:

```makefile
.PHONY: create-role create-functions deploy-functions deploy-state-machine deps
```

What is `deploys-functions` and `deploy-state-machine`? Are those scripts missing? or how it works?